### PR TITLE
Removed role perms not held by namespace admins

### DIFF
--- a/tekton/base/triggers/rbac.yaml
+++ b/tekton/base/triggers/rbac.yaml
@@ -23,10 +23,6 @@ rules:
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["impersonate"]
-- apiGroups: ["policy"]
-  resources: ["podsecuritypolicies"]
-  resourceNames: ["tekton-triggers"]
-  verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -39,26 +35,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: tekton-triggers-example-minimal
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: tekton-triggers-example-clusterrole
-rules:
-  # EventListeners need to be able to fetch any clustertriggerbindings
-- apiGroups: ["triggers.tekton.dev"]
-  resources: ["clustertriggerbindings", "clusterinterceptors"]
-  verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: tekton-triggers-example-clusterbinding
-subjects:
-- kind: ServiceAccount
-  name: service-tekton-triggers-sa
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-triggers-example-clusterrole


### PR DESCRIPTION
Our namespace admins don't have some permissions that are defined in `tekton/base/triggers/rbac.yaml`, namely:
```
- apiGroups: ["policy"]
  resources: ["podsecuritypolicies"]
  resourceNames: ["tekton-triggers"]
  verbs: ["use"]
```
and 
```
- apiGroups: ["triggers.tekton.dev"]
  resources: ["clustertriggerbindings", "clusterinterceptors"]
  verbs: ["get", "list", "watch"]
```
If these will really be necessary in order to use these pipelines, then we can look at updating the ClusterRole.