### PR TITLE
Changes for 201 Pipelines lab take 2

### DIFF
--- a/tekton/base/triggers/trigger-maven-build.yaml
+++ b/tekton/base/triggers/trigger-maven-build.yaml
@@ -14,6 +14,10 @@ spec:
     default: main
   - name: pathToContext
     default: ./tekton/demo/maven-test
+  - name: runSonarScan
+    default: 'true'
+  - name: sonarProject
+    default: bcgov_pipeline-templates
   resourcetemplates:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
@@ -33,6 +37,10 @@ spec:
         value: $(tt.params.branchName)
       - name: pathToContext
         value: $(tt.params.pathToContext)
+      - name: runSonarScan
+        value: $(tt.params.runSonarScan)
+      - name: sonarProject
+        value: $(tt.params.sonarProject)
       workspaces:
       - name: shared-data
         volumeClaimTemplate:


### PR DESCRIPTION
There was a bug found in the pipeline lab where we weren't passing the required params `runSonarScan` and `sonarProject` to the Pipeline from the TriggerTemplate.

These changes fix that issue.