### PR TITLE
Fix capitalization in 'GitHub'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This repo contains a catalog of pipeline templates to kickstart development amon
 ## Documentation
 
 - [Tekton Templates](https://github.com/bcgov/pipeline-templates/tree/main/tekton)
-- [Github Templates](docs/github.md)
+- [GitHub Templates](docs/github.md)
 - [ZAP Scanning Report](https://github.com/bcgov/security-pipeline-templates/blob/zap-scan/README.md)


### PR DESCRIPTION
This pull request is to test whether our `pre-commit` job is succeeding after linting fixes.

It looks like the job failed has failed at the [Analyze Kustomize Manifests step](https://github.com/bcgov/pipeline-templates/runs/7509014120?check_suite_focus=true).